### PR TITLE
fix: Incorrect tops were displayed

### DIFF
--- a/CashFlow/Gui/BaseTabs/TabRetainerSales.cs
+++ b/CashFlow/Gui/BaseTabs/TabRetainerSales.cs
@@ -77,7 +77,7 @@ public unsafe class TabRetainerSales : BaseTab<RetainerSaleDescriptor>
         if(C.DisplayExclusionsRetainerSalesMannequinn.Contains(data.CidUlong) && data.IsMannequinn) return;
         var id = (uint)data.ItemID % 1_000_000u;
         if(!ItemValues.ContainsKey(id)) ItemValues[id] = 0;
-        ItemValues[id] += data.Price * data.Quantity;
+        ItemValues[id] += data.Price;
         base.AddData(data, list);
     }
 


### PR DESCRIPTION
Removed quantity multiplier in the ItemValues of sales, this was not necessary as the price is not by unit. (It was already good in NPCSales so I guess it slipped :D)

(Pardon my French)

| Before | After |
| -- | -- |
| <img width="303" height="152" alt="image" src="https://github.com/user-attachments/assets/046a4547-323e-49b2-88c3-f777d75fddb9" /> | <img width="288" height="148" alt="image" src="https://github.com/user-attachments/assets/845fa61f-69db-4113-80fa-27af88631784" /> |